### PR TITLE
Hotfix/Fix db session expire on commit error

### DIFF
--- a/db/engine.py
+++ b/db/engine.py
@@ -28,7 +28,7 @@ url_object = URL.create(
 )
 
 engine = create_engine(url_object)
-Session = scoped_session(sessionmaker(bind=engine))
+Session = scoped_session(sessionmaker(bind=engine, expire_on_commit=False))
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Хотфикс, предотвращение истечения срока жизни объектов вне транзакции после `Session.commit()`